### PR TITLE
A minor change to use the default system look and feel.

### DIFF
--- a/lib/velvet_gui.rb
+++ b/lib/velvet_gui.rb
@@ -40,6 +40,7 @@ include_class %w(java.awt.event.ActionListener
                  javax.swing.JTabbedPane
                  javax.swing.border.TitledBorder
                  javax.swing.text.DefaultCaret
+                 javax.swing.UIManager
                 )
 
 class Settings
@@ -477,6 +478,8 @@ class VelvetGUI < JFrame
   def initialize
     super "Vague"
 
+    UIManager::look_and_feel = UIManager::getSystemLookAndFeelClassName
+    
     path = Settings.velvet_directory
     update_velvet_binary(path)
 


### PR DESCRIPTION
JRuby apps look pretty unsightly on ubuntu using the basic look and feel. This commit ensures that the Velvet GUI always uses the system's (less ugly) default.
